### PR TITLE
fix: keep top bar full width without an open module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A note-taking app for organizing an Obsidian vault with a consistent module/topi
 - Rename module categories directly from the module page
 - Reorder module categories and lecture notes with persisted drag-and-drop sorting
 - Keep the active lecture in sync with the most visible note while scrolling
+- Full-width top navigation keeps module actions available before a module is open
 - Notes grouped by tags and still fully Obsidian-compatible (wikilinks, markdown, etc.)
 - Built-in RAG chat over your vault notes
 - Organisation tool to quickly and easily tag repositories

--- a/frontend/src/Components/Layout/SidebarLayout.tsx
+++ b/frontend/src/Components/Layout/SidebarLayout.tsx
@@ -122,7 +122,6 @@ export default function SidebarLayout({
         <Box
           sx={{
             width: "100%",
-            maxWidth: contentMaxWidth,
             mx: "auto",
             px: { xs: 2, sm: 4 },
             py: 1.5,


### PR DESCRIPTION
## Summary
- decouple the sticky top bar width from the dashboard content max width
- keep the empty dashboard state constrained while the top navigation stays full width
- update the README feature list to match the current layout behaviour

## Testing
- `cd frontend && make lint`
- `cd frontend && npm run build`

## Issues
- Closes #46