### PR TITLE
feat: add a top bar pomodoro timer with stronger completion alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A note-taking app for organizing an Obsidian vault with a consistent module/topi
 - Reorder module categories and lecture notes with persisted drag-and-drop sorting
 - Keep the active lecture in sync with the most visible note while scrolling
 - Full-width top navigation keeps module actions available before a module is open
-- Built-in 25/5 Pomodoro timer in the top bar with a completion beep
+- Built-in 25/5 Pomodoro timer in the top bar with a repeating completion alarm and system notification on focus completion
 - Notes grouped by tags and still fully Obsidian-compatible (wikilinks, markdown, etc.)
 - Built-in RAG chat over your vault notes
 - Organisation tool to quickly and easily tag repositories

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A note-taking app for organizing an Obsidian vault with a consistent module/topi
 - Reorder module categories and lecture notes with persisted drag-and-drop sorting
 - Keep the active lecture in sync with the most visible note while scrolling
 - Full-width top navigation keeps module actions available before a module is open
+- Built-in 25/5 Pomodoro timer in the top bar with a completion beep
 - Notes grouped by tags and still fully Obsidian-compatible (wikilinks, markdown, etc.)
 - Built-in RAG chat over your vault notes
 - Organisation tool to quickly and easily tag repositories

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A note-taking app for organizing an Obsidian vault with a consistent module/topi
 - Rename module categories directly from the module page
 - Reorder module categories and lecture notes with persisted drag-and-drop sorting
 - Keep the active lecture in sync with the most visible note while scrolling
+- Full-width top navigation keeps module actions available before a module is open
 - Notes grouped by tags and still fully Obsidian-compatible (wikilinks, markdown, etc.)
 - Built-in RAG chat over your vault notes
 - Organisation tool to quickly and easily tag repositories

--- a/frontend/src/Components/Layout/PomodoroTimer.tsx
+++ b/frontend/src/Components/Layout/PomodoroTimer.tsx
@@ -107,7 +107,6 @@ function playCompletionBeep(audioContextRef: MutableRefObject<AudioContext | nul
 export default function PomodoroTimer() {
   const [timerState, setTimerState] = useState<TimerState>(() => loadStoredState());
   const audioContextRef = useRef<AudioContext | null>(null);
-  const phaseLabel = timerState.phase === "work" ? "Focus" : "Break";
   const timerDisplay = useMemo(() => formatTime(timerState.remainingSeconds), [timerState.remainingSeconds]);
 
   useEffect(() => {
@@ -191,31 +190,59 @@ export default function PomodoroTimer() {
     setTimerState(createTimerState(timerState.phase, false, getPhaseDuration(timerState.phase)));
   };
 
+  const cycleTimerLength = () => {
+    setTimerState((currentState) => {
+      const nextPhase = getNextPhase(currentState.phase);
+      return createTimerState(nextPhase, false, getPhaseDuration(nextPhase));
+    });
+  };
+
   return (
     <Box
       sx={{
         justifySelf: "center",
-        minWidth: { xs: "auto", md: 220 },
+        display: "flex",
+        justifyContent: "center",
       }}
     >
       <Stack
         direction="row"
-        spacing={1}
+        spacing={0.25}
         alignItems="center"
         sx={{
-          px: 1.25,
+          px: 0.75,
           py: 0.5,
           borderRadius: "6px",
           border: "1px solid rgba(255,255,255,0.07)",
           backgroundColor: "#141414",
         }}
       >
-        <Box sx={{ minWidth: { xs: 64, sm: 72 } }}>
-          <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.1 }}>
-            Pomodoro
-          </Typography>
+        <Box
+          component="button"
+          onClick={cycleTimerLength}
+          sx={{
+            border: 0,
+            backgroundColor: "transparent",
+            color: "text.primary",
+            cursor: "pointer",
+            borderRadius: "6px",
+            px: 1,
+            py: 0.5,
+            minWidth: 72,
+            transition: "background-color 150ms ease-out, color 150ms ease-out",
+            "&:hover": {
+              backgroundColor: "rgba(255,255,255,0.04)",
+            },
+            "&:focus-visible": {
+              outline: "2px solid #e0e0e0",
+              outlineOffset: 2,
+            },
+          }}
+          aria-label="Cycle pomodoro timer length"
+          title="Cycle between 25 and 5 minutes"
+        >
           <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
-            {phaseLabel} {timerDisplay}
+            {timerDisplay}
           </Typography>
         </Box>
 

--- a/frontend/src/Components/Layout/PomodoroTimer.tsx
+++ b/frontend/src/Components/Layout/PomodoroTimer.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import { Box, IconButton, Stack, Tooltip, Typography } from "@mui/material";
-import { FaPause, FaPlay, FaRotateLeft } from "react-icons/fa6";
+import { FaPause, FaPlay, FaRotateLeft, FaStop } from "react-icons/fa6";
 
 const WORK_DURATION_SECONDS = 25 * 60;
 const BREAK_DURATION_SECONDS = 5 * 60;
 const STORAGE_KEY = "obsidian-pomodoro-timer";
+const COMPLETION_BEEP_COUNT = 5;
+const COMPLETION_BEEP_INTERVAL_SECONDS = 0.24;
+const COMPLETION_BEEP_DURATION_SECONDS = 0.12;
+const COMPLETION_BEEP_REPEAT_MS = 1800;
 
 type PomodoroPhase = "work" | "break";
 
@@ -87,31 +91,83 @@ async function resumeAudioContext(audioContextRef: MutableRefObject<AudioContext
   }
 }
 
+async function requestNotificationPermission(): Promise<void> {
+  if (!("Notification" in window) || Notification.permission !== "default") {
+    return;
+  }
+
+  try {
+    await Notification.requestPermission();
+  } catch (error) {
+    console.error("Unable to request pomodoro notification permission", error);
+  }
+}
+
 function playCompletionBeep(audioContextRef: MutableRefObject<AudioContext | null>): void {
   const audioContext = audioContextRef.current ?? new AudioContext();
   audioContextRef.current = audioContext;
 
-  const oscillator = audioContext.createOscillator();
-  const gainNode = audioContext.createGain();
-  oscillator.type = "sine";
-  oscillator.frequency.setValueAtTime(880, audioContext.currentTime);
-  oscillator.connect(gainNode);
-  gainNode.connect(audioContext.destination);
-  gainNode.gain.setValueAtTime(0.0001, audioContext.currentTime);
-  gainNode.gain.exponentialRampToValueAtTime(0.08, audioContext.currentTime + 0.01);
-  gainNode.gain.exponentialRampToValueAtTime(0.0001, audioContext.currentTime + 0.35);
-  oscillator.start(audioContext.currentTime);
-  oscillator.stop(audioContext.currentTime + 0.35);
+  for (let index = 0; index < COMPLETION_BEEP_COUNT; index += 1) {
+    const startTime = audioContext.currentTime + index * COMPLETION_BEEP_INTERVAL_SECONDS;
+    const stopTime = startTime + COMPLETION_BEEP_DURATION_SECONDS;
+    const oscillator = audioContext.createOscillator();
+    const gainNode = audioContext.createGain();
+
+    oscillator.type = "square";
+    oscillator.frequency.setValueAtTime(1046, startTime);
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+    gainNode.gain.setValueAtTime(0.0001, startTime);
+    gainNode.gain.exponentialRampToValueAtTime(0.12, startTime + 0.01);
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, stopTime);
+    oscillator.start(startTime);
+    oscillator.stop(stopTime);
+  }
+}
+
+function sendCompletionNotification(phase: PomodoroPhase): void {
+  if (!("Notification" in window) || Notification.permission !== "granted") {
+    return;
+  }
+
+  const notificationCopy = phase === "work"
+    ? { title: "Pomodoro complete", body: "Time for a break." }
+    : { title: "Break complete", body: "Time to get back to work." };
+
+  try {
+    new Notification(notificationCopy.title, { body: notificationCopy.body });
+  } catch (error) {
+    console.error("Unable to send pomodoro notification", error);
+  }
 }
 
 export default function PomodoroTimer() {
   const [timerState, setTimerState] = useState<TimerState>(() => loadStoredState());
+  const [isAlarmActive, setIsAlarmActive] = useState(false);
   const audioContextRef = useRef<AudioContext | null>(null);
+  const alarmIntervalRef = useRef<number | null>(null);
   const timerDisplay = useMemo(() => formatTime(timerState.remainingSeconds), [timerState.remainingSeconds]);
+
+  const stopAlarm = () => {
+    if (alarmIntervalRef.current !== null) {
+      window.clearInterval(alarmIntervalRef.current);
+      alarmIntervalRef.current = null;
+    }
+
+    setIsAlarmActive(false);
+  };
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(timerState));
   }, [timerState]);
+
+  useEffect(() => {
+    return () => {
+      if (alarmIntervalRef.current !== null) {
+        window.clearInterval(alarmIntervalRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!timerState.isRunning || timerState.endTime === null) {
@@ -131,6 +187,7 @@ export default function PomodoroTimer() {
       }
 
       window.clearInterval(intervalId);
+      const completedPhase = timerState.phase;
       const nextPhase = getNextPhase(timerState.phase);
       const nextDuration = getPhaseDuration(nextPhase);
 
@@ -141,10 +198,28 @@ export default function PomodoroTimer() {
         endTime: Date.now() + nextDuration * 1000,
       });
 
-      try {
-        playCompletionBeep(audioContextRef);
-      } catch (error) {
-        console.error("Unable to play pomodoro timer beep", error);
+      if (completedPhase === "work") {
+        if (alarmIntervalRef.current !== null) {
+          window.clearInterval(alarmIntervalRef.current);
+        }
+
+        setIsAlarmActive(true);
+
+        try {
+          playCompletionBeep(audioContextRef);
+        } catch (error) {
+          console.error("Unable to play pomodoro timer beep", error);
+        }
+
+        alarmIntervalRef.current = window.setInterval(() => {
+          try {
+            playCompletionBeep(audioContextRef);
+          } catch (error) {
+            console.error("Unable to play pomodoro timer beep", error);
+          }
+        }, COMPLETION_BEEP_REPEAT_MS);
+
+        sendCompletionNotification(completedPhase);
       }
     }, 250);
 
@@ -153,9 +228,12 @@ export default function PomodoroTimer() {
 
   const startTimer = async () => {
     try {
-      await resumeAudioContext(audioContextRef);
+      await Promise.all([
+        resumeAudioContext(audioContextRef),
+        requestNotificationPermission(),
+      ]);
     } catch (error) {
-      console.error("Unable to prepare pomodoro timer audio", error);
+      console.error("Unable to prepare pomodoro timer", error);
     }
 
     setTimerState((currentState) => {
@@ -247,6 +325,13 @@ export default function PomodoroTimer() {
         </Box>
 
         <Stack direction="row" spacing={0.25} alignItems="center">
+          {isAlarmActive ? (
+            <Tooltip title="Stop alarm">
+              <IconButton size="small" onClick={stopAlarm} aria-label="Stop pomodoro alarm">
+                <FaStop size={12} />
+              </IconButton>
+            </Tooltip>
+          ) : null}
           <Tooltip title={timerState.isRunning ? "Pause timer" : "Start timer"}>
             <IconButton
               size="small"

--- a/frontend/src/Components/Layout/PomodoroTimer.tsx
+++ b/frontend/src/Components/Layout/PomodoroTimer.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+import { Box, IconButton, Stack, Tooltip, Typography } from "@mui/material";
+import { FaPause, FaPlay, FaRotateLeft } from "react-icons/fa6";
+
+const WORK_DURATION_SECONDS = 25 * 60;
+const BREAK_DURATION_SECONDS = 5 * 60;
+const STORAGE_KEY = "obsidian-pomodoro-timer";
+
+type PomodoroPhase = "work" | "break";
+
+type TimerState = {
+  phase: PomodoroPhase;
+  isRunning: boolean;
+  remainingSeconds: number;
+  endTime: number | null;
+};
+
+function getPhaseDuration(phase: PomodoroPhase): number {
+  return phase === "work" ? WORK_DURATION_SECONDS : BREAK_DURATION_SECONDS;
+}
+
+function getNextPhase(phase: PomodoroPhase): PomodoroPhase {
+  return phase === "work" ? "break" : "work";
+}
+
+function createTimerState(phase: PomodoroPhase, isRunning: boolean, remainingSeconds: number): TimerState {
+  return {
+    phase,
+    isRunning,
+    remainingSeconds,
+    endTime: isRunning ? Date.now() + remainingSeconds * 1000 : null,
+  };
+}
+
+function loadStoredState(): TimerState {
+  const fallbackState = createTimerState("work", false, WORK_DURATION_SECONDS);
+  const rawState = localStorage.getItem(STORAGE_KEY);
+
+  if (!rawState) {
+    return fallbackState;
+  }
+
+  try {
+    const parsed = JSON.parse(rawState) as Partial<TimerState>;
+    const phase = parsed.phase === "break" ? "break" : "work";
+    const isRunning = parsed.isRunning === true;
+    const remainingSeconds = typeof parsed.remainingSeconds === "number"
+      ? Math.max(0, Math.floor(parsed.remainingSeconds))
+      : getPhaseDuration(phase);
+    const endTime = typeof parsed.endTime === "number" ? parsed.endTime : null;
+
+    if (!isRunning || endTime === null) {
+      return {
+        phase,
+        isRunning: false,
+        remainingSeconds,
+        endTime: null,
+      };
+    }
+
+    return {
+      phase,
+      isRunning: true,
+      remainingSeconds: Math.max(0, Math.ceil((endTime - Date.now()) / 1000)),
+      endTime,
+    };
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+    return fallbackState;
+  }
+}
+
+function formatTime(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+async function resumeAudioContext(audioContextRef: MutableRefObject<AudioContext | null>): Promise<void> {
+  const audioContext = audioContextRef.current ?? new AudioContext();
+  audioContextRef.current = audioContext;
+
+  if (audioContext.state === "suspended") {
+    await audioContext.resume();
+  }
+}
+
+function playCompletionBeep(audioContextRef: MutableRefObject<AudioContext | null>): void {
+  const audioContext = audioContextRef.current ?? new AudioContext();
+  audioContextRef.current = audioContext;
+
+  const oscillator = audioContext.createOscillator();
+  const gainNode = audioContext.createGain();
+  oscillator.type = "sine";
+  oscillator.frequency.setValueAtTime(880, audioContext.currentTime);
+  oscillator.connect(gainNode);
+  gainNode.connect(audioContext.destination);
+  gainNode.gain.setValueAtTime(0.0001, audioContext.currentTime);
+  gainNode.gain.exponentialRampToValueAtTime(0.08, audioContext.currentTime + 0.01);
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, audioContext.currentTime + 0.35);
+  oscillator.start(audioContext.currentTime);
+  oscillator.stop(audioContext.currentTime + 0.35);
+}
+
+export default function PomodoroTimer() {
+  const [timerState, setTimerState] = useState<TimerState>(() => loadStoredState());
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const phaseLabel = timerState.phase === "work" ? "Focus" : "Break";
+  const timerDisplay = useMemo(() => formatTime(timerState.remainingSeconds), [timerState.remainingSeconds]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(timerState));
+  }, [timerState]);
+
+  useEffect(() => {
+    if (!timerState.isRunning || timerState.endTime === null) {
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      const nextRemainingSeconds = Math.max(0, Math.ceil((timerState.endTime as number - Date.now()) / 1000));
+
+      if (nextRemainingSeconds > 0) {
+        setTimerState((currentState) => (
+          currentState.remainingSeconds === nextRemainingSeconds
+            ? currentState
+            : { ...currentState, remainingSeconds: nextRemainingSeconds }
+        ));
+        return;
+      }
+
+      window.clearInterval(intervalId);
+      const nextPhase = getNextPhase(timerState.phase);
+      const nextDuration = getPhaseDuration(nextPhase);
+
+      setTimerState({
+        phase: nextPhase,
+        isRunning: true,
+        remainingSeconds: nextDuration,
+        endTime: Date.now() + nextDuration * 1000,
+      });
+
+      try {
+        playCompletionBeep(audioContextRef);
+      } catch (error) {
+        console.error("Unable to play pomodoro timer beep", error);
+      }
+    }, 250);
+
+    return () => window.clearInterval(intervalId);
+  }, [timerState.endTime, timerState.isRunning, timerState.phase]);
+
+  const startTimer = async () => {
+    try {
+      await resumeAudioContext(audioContextRef);
+    } catch (error) {
+      console.error("Unable to prepare pomodoro timer audio", error);
+    }
+
+    setTimerState((currentState) => {
+      if (currentState.isRunning) {
+        return currentState;
+      }
+
+      return {
+        ...currentState,
+        isRunning: true,
+        endTime: Date.now() + currentState.remainingSeconds * 1000,
+      };
+    });
+  };
+
+  const pauseTimer = () => {
+    setTimerState((currentState) => {
+      if (!currentState.isRunning || currentState.endTime === null) {
+        return currentState;
+      }
+
+      return {
+        ...currentState,
+        isRunning: false,
+        remainingSeconds: Math.max(0, Math.ceil((currentState.endTime - Date.now()) / 1000)),
+        endTime: null,
+      };
+    });
+  };
+
+  const resetTimer = () => {
+    setTimerState(createTimerState(timerState.phase, false, getPhaseDuration(timerState.phase)));
+  };
+
+  return (
+    <Box
+      sx={{
+        justifySelf: "center",
+        minWidth: { xs: "auto", md: 220 },
+      }}
+    >
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        sx={{
+          px: 1.25,
+          py: 0.5,
+          borderRadius: "6px",
+          border: "1px solid rgba(255,255,255,0.07)",
+          backgroundColor: "#141414",
+        }}
+      >
+        <Box sx={{ minWidth: { xs: 64, sm: 72 } }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.1 }}>
+            Pomodoro
+          </Typography>
+          <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+            {phaseLabel} {timerDisplay}
+          </Typography>
+        </Box>
+
+        <Stack direction="row" spacing={0.25} alignItems="center">
+          <Tooltip title={timerState.isRunning ? "Pause timer" : "Start timer"}>
+            <IconButton
+              size="small"
+              onClick={timerState.isRunning ? pauseTimer : startTimer}
+              aria-label={timerState.isRunning ? "Pause pomodoro timer" : "Start pomodoro timer"}
+            >
+              {timerState.isRunning ? <FaPause size={12} /> : <FaPlay size={12} />}
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Reset timer">
+            <IconButton size="small" onClick={resetTimer} aria-label="Reset pomodoro timer">
+              <FaRotateLeft size={12} />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/Components/Layout/SidebarLayout.tsx
+++ b/frontend/src/Components/Layout/SidebarLayout.tsx
@@ -122,7 +122,6 @@ export default function SidebarLayout({
         <Box
           sx={{
             width: "100%",
-            maxWidth: contentMaxWidth,
             mx: "auto",
             px: { xs: 2, sm: 4 },
             py: 1.5,

--- a/frontend/src/Components/Layout/SidebarLayout.tsx
+++ b/frontend/src/Components/Layout/SidebarLayout.tsx
@@ -123,7 +123,6 @@ export default function SidebarLayout({
         <Box
           sx={{
             width: "100%",
-            maxWidth: "1400px",
             mx: "auto",
             px: { xs: 2, sm: 4 },
             py: 1.5,

--- a/frontend/src/Components/Layout/SidebarLayout.tsx
+++ b/frontend/src/Components/Layout/SidebarLayout.tsx
@@ -149,7 +149,7 @@ export default function SidebarLayout({
               direction="row"
               spacing={1.25}
               alignItems="center"
-              sx={{ justifySelf: "end", gridColumn: { xs: "1 / -1", md: "auto" }, flexWrap: "wrap" }}
+              sx={{ justifySelf: "end", justifyContent: "flex-end", gridColumn: { xs: "1 / -1", md: "auto" }, flexWrap: "wrap" }}
             >
               {topBarLink({
                 label: "Ask Vault",

--- a/frontend/src/Components/Layout/SidebarLayout.tsx
+++ b/frontend/src/Components/Layout/SidebarLayout.tsx
@@ -4,6 +4,7 @@ import { Box, Drawer, Stack, Tooltip, Typography } from "@mui/material";
 import { FaBars, FaRegFileLines, FaTableColumns } from "react-icons/fa6";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import PomodoroTimer from "./PomodoroTimer";
 import TagList from "../TagList/TagList";
 import type { PrimaryTag } from "../../Utils/types/api.schemas";
 
@@ -122,19 +123,35 @@ export default function SidebarLayout({
         <Box
           sx={{
             width: "100%",
+            maxWidth: "1400px",
             mx: "auto",
             px: { xs: 2, sm: 4 },
             py: 1.5,
           }}
         >
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "auto 1fr", md: "1fr auto 1fr" },
+              alignItems: "center",
+              columnGap: 2,
+              rowGap: 1.5,
+            }}
+          >
             <Tooltip title={open ? "Close modules" : "Open modules"}>
-              <Box>
+              <Box sx={{ justifySelf: "start" }}>
                 {modulesTrigger}
               </Box>
             </Tooltip>
 
-            <Stack direction="row" spacing={1.25} alignItems="center">
+            <PomodoroTimer />
+
+            <Stack
+              direction="row"
+              spacing={1.25}
+              alignItems="center"
+              sx={{ justifySelf: "end", gridColumn: { xs: "1 / -1", md: "auto" }, flexWrap: "wrap" }}
+            >
               {topBarLink({
                 label: "Ask Vault",
                 icon: <FaRegFileLines size={14} />,
@@ -148,7 +165,7 @@ export default function SidebarLayout({
                 onClick: () => navigate("/organization-tool"),
               })}
             </Stack>
-          </Stack>
+          </Box>
         </Box>
       </Box>
 


### PR DESCRIPTION
## Summary
- add a centered 25/5 pomodoro timer to the sticky top bar with start, pause, reset, and phase toggle controls
- persist timer state across refreshes, auto-switch between focus and break phases, and trigger a repeating five-beep alarm on focus completion until it is explicitly stopped
- request browser notification permission on timer start, send a system notification when focus ends, and document the stronger alert behavior in the README

## Testing
- `cd frontend && make lint`
- `cd frontend && npm run build`

## Notes
- `cd frontend && make lint` still reports pre-existing warnings from `frontend/coverage/*`

## Issues
- Closes #48